### PR TITLE
fix typo backgrond > background

### DIFF
--- a/src/_packs/mixins/seed-color-scheme.md
+++ b/src/_packs/mixins/seed-color-scheme.md
@@ -205,7 +205,7 @@ $color-scheme: (
 
 // Use your color scheme
 html {
-  backgrond: _color(app, background);
+  background: _color(app, background);
 }
 ```
 


### PR DESCRIPTION
Fixed typo in the Namespacing section from backgrond to background